### PR TITLE
Fix build when both MUNIT_NO_BUFFER and MUNIT_NO_FORK are defined

### DIFF
--- a/munit.c
+++ b/munit.c
@@ -1251,7 +1251,7 @@ munit_test_runner_print_color(const MunitTestRunner* runner, const char* string,
     fputs(string, MUNIT_OUTPUT_FILE);
 }
 
-#if !defined(MUNIT_NO_BUFFER)
+#if !defined(MUNIT_NO_BUFFER) || !defined(MUNIT_NO_FORK)
 static int
 munit_replace_stderr(FILE* stderr_buf) {
   if (stderr_buf != NULL) {


### PR DESCRIPTION
Pull in Syeberman's fix
https://github.com/nemequ/munit/pull/101